### PR TITLE
Reuse `Name` instances to improve performance

### DIFF
--- a/src/Models/Naming/Name.php
+++ b/src/Models/Naming/Name.php
@@ -54,7 +54,7 @@ class Name
 
     public static function forModel(object $model)
     {
-        $class = get_class($model);
+        $class = $model::class;
 
         return static::$nameInstanceCache[$class] ??= static::build($class);
     }

--- a/src/Models/Naming/Name.php
+++ b/src/Models/Naming/Name.php
@@ -50,9 +50,13 @@ class Name
      */
     public string $element;
 
+    private static array $nameInstanceCache = [];
+
     public static function forModel(object $model)
     {
-        return static::build(get_class($model));
+        $class = get_class($model);
+
+        return static::$nameInstanceCache[$class] ??= static::build($class);
     }
 
     public static function build(string $className)


### PR DESCRIPTION
I have a project with a lot of components and `dom_id` or `dom_class` being called hundreds of times on each page load.

This PR optimizes the performance of these functions by reusing `Name` instances such that the name for a particular class only ever has to be calculated once.

The calculation (in the `Tonysm\TurboLaravel\Models\Naming\Name::build` method) is actually somewhat expensive when done in large quantities – mostly as a result of the use of the `config` helper in `removeRootNamespaces` (resolving from the container each time adds up), and the call to `Str::plural`.

Ideally the public properties of the `Name` class would be made `readonly` so these instances are immutable, however would require dropping PHP 8.0 support.