### PR TITLE
Fix model broadcast was not being triggered when using model touching

### DIFF
--- a/src/Models/ModelObserver.php
+++ b/src/Models/ModelObserver.php
@@ -21,25 +21,17 @@ class ModelObserver
     /**
      * @param Model|Broadcasts $model
      */
-    public function created(Model $model)
+    public function saved(Model $model)
     {
         if (! $this->shouldBroadcast($model)) {
             return;
         }
 
-        $model->broadcastInsert()->later();
-    }
-
-    /**
-     * @param Model|Broadcasts $model
-     */
-    public function updated(Model $model)
-    {
-        if (! $this->shouldBroadcast($model)) {
-            return;
+        if ($model->wasRecentlyCreated) {
+            $model->broadcastInsert()->later();
+        } else {
+            $model->broadcastReplace()->later();
         }
-
-        $model->broadcastReplace()->later();
     }
 
     /**

--- a/tests/Stubs/views/posts/_post.blade.php
+++ b/tests/Stubs/views/posts/_post.blade.php
@@ -1,0 +1,1 @@
+<div>{{ $post->title }}</div>

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -45,5 +45,19 @@ class TestCase extends Orchestra
             $table->timestamps();
             $table->softDeletes();
         });
+
+        $app['db']->connection()->getSchemaBuilder()->create('posts', function (Blueprint $table) {
+            $table->id();
+            $table->string('title');
+            $table->text('body')->nullable();
+            $table->timestamps();
+        });
+
+        $app['db']->connection()->getSchemaBuilder()->create('comments', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('post_id');
+            $table->text('body');
+            $table->timestamps();
+        });
     }
 }


### PR DESCRIPTION
### Fixed

- Model touching wasn't triggering the parent's broadcasts. Looks like only the `saved` event is fired when the parent's timestamps are updated, not the `updated` event.